### PR TITLE
add entries from github python.gitignore to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,119 @@
-env/
-.coverage
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
 htmlcov/
-.ropeproject
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
 *.sqlite3
 *.db
-*.py[cod]
-*.swp
-*.aux
-*.log
-*.toc
-*.mo
-*~
-__pycache__/
 _static/
 .secret
-atlassian-ide-plugin.xml
-local/
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+doc/_build/
+*.toc
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# editors
+*.swp
+*.aux
+*~
 .project
 .pydevproject
+.vscode
+
+# IDEA / pycharm
 .idea/
+atlassian-ide-plugin.xml
+
+# generic local files
+local/


### PR DESCRIPTION
This adds entries from [github python.gitignore](https://github.com/github/gitignore/blob/master/Python.gitignore) to `.gitignore`. It helps new developers, who might use a different tool chain to get started with this project.