### PR TITLE
[orga] replace stackstrace w/ error message when adding an empty mail to talk

### DIFF
--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -92,7 +92,7 @@ class SubmissionSpeakersAdd(View):
         except User.DoesNotExist:
             speaker = create_user_as_orga(request.POST.get('nick'), submission=submission)
         if not speaker:
-            messages.error(_('Please provide a valid nick or email address!'))
+            messages.error(request, _('Please provide a valid nick or email address!'))
         else:
             if submission not in speaker.submissions.all():
                 speaker.submissions.add(submission)


### PR DESCRIPTION
When you submit an empty speaker name/mail on `/orga/event/foo/submissions/2/speakers`, the app crashes, because `messages.error` is not called properly. This PR makes it display the desired message properly.