### PR TITLE
[orga] try to make the buttons in schedule editor clearer

### DIFF
--- a/src/pretalx/orga/templates/orga/schedule/index.html
+++ b/src/pretalx/orga/templates/orga/schedule/index.html
@@ -40,15 +40,16 @@
         <div id="schedule-choice">
             <div class="input-group">
                 <form class="form-inline">
-                    <select name="version" class="form-control">
-                        <option value="">{% trans "Editor version" %}</option>
+                    <label for="version">{% trans "Version:" %}&nbsp;</label>
+                    <select name="version" id="version" class="form-control">
+                        <option value="">{% trans "Current draft" %}</option>
                         {% for schedule in request.event.schedules.all %}
                             {% if schedule.version %}
                                 <option value="{{ schedule.version }}" {% if schedule.version == schedule_version %}selected{% endif %}>{{ schedule.version }}</option>
                             {% endif %}
                         {% endfor %}
                     </select>
-                    <button type="submit" class="btn btn-primary">{% trans "Go" %}</button>
+                    <button type="submit" class="btn btn-primary">{% trans "View" %}</button>
                 </form>
             </div>
         </div>
@@ -63,7 +64,7 @@
             </div>
         {% else %}
             <form method="post" action="{{ request.event.orga_urls.reset_schedule }}?{{ request.GET.urlencode }}">
-                <button type="submit" class="btn btn-secondary">{% trans "Edit this version" %}</button>
+                <button type="submit" class="btn btn-secondary">{% trans "Reset to selected version" %}</button>
             </form>
         {% endif %}
     </div>

--- a/src/pretalx/static/orga/scss/_schedule.scss
+++ b/src/pretalx/static/orga/scss/_schedule.scss
@@ -11,7 +11,7 @@ h3, .schedule-header, .schedule-alert {
   width: 260px;
 }
 #schedule-choice {
-  width: 200px;
+  width: 300px;
   select {
     height: 38px;
   }


### PR DESCRIPTION
The schedule editor already looks great, but the buttons on the top kind of confused me. I tried to give them better names. Please note that this is only a suggestion, feel free to make or request any changes you want :)