### PR TITLE
[agenda] ensure that talks for non-public events are inaccessible via their url

### DIFF
--- a/src/pretalx/agenda/views/schedule.py
+++ b/src/pretalx/agenda/views/schedule.py
@@ -160,7 +160,7 @@ class FrabJsonView(ScheduleDataView):
         return JsonResponse({'schedule': result})
 
 
-class TalkView(DetailView):
+class TalkView(EventPageMixin, DetailView):
     context_object_name = 'talk'
     model = Submission
     slug_field = 'code'


### PR DESCRIPTION
Events that are not public yet just display a 404-page for their schedule and main public pages. Talks should be hidden as well, just in case the url is shared somewhere by accident.