### PR TITLE
[agenda] make speaker links on public talk pages bold, as planned

### DIFF
--- a/src/pretalx/static/agenda/scss/_speaker.scss
+++ b/src/pretalx/static/agenda/scss/_speaker.scss
@@ -40,7 +40,7 @@
       border-top: 1px solid rgba(0, 0, 0, 0.1);
     }
 
-    a.speaker {
+    .speaker a {
       font-weight: bold;
     }
   }


### PR DESCRIPTION
The agenda scss contains a selector `a.speaker` to make speaker links on public talk pages bold. But there is no `<a class="speaker">` on that page. Only a `<div class="speaker"><a>`. This PR reflects the actual HTML structure in CSS.