### PR TITLE
[agenda] add speaker page

### DIFF
--- a/src/pretalx/agenda/templates/agenda/speaker.html
+++ b/src/pretalx/agenda/templates/agenda/speaker.html
@@ -1,0 +1,38 @@
+{% extends "agenda/base.html" %}
+{% load i18n %}
+
+{% block content %}
+<h3>
+    {{ speaker.nick }}
+    {% if speaker.name %}
+        <small>{{ speaker.name }}</small>
+    {% endif %}
+</h3>
+
+<div class="row">
+    <div class="col-lg-8 col-md-6 col-xs-12">
+        {% if speaker.biography %}
+            {{ speaker.biography }}
+        {% else %}
+            {% trans 'This speaker did not provide a biography yet.' %}
+        {% endif %}
+    </div>
+    <div class="col-lg-4 col-md-6 col-xs-12">
+        <div class="bordered-list">
+            <div class="header">
+                {% blocktrans trimmed count count=submissions.count %}
+                Talk
+                {% plural %}
+                Talks
+                {% endblocktrans %}
+            </div>
+            {% for submission in submissions %}
+                <div class="info">
+                    <div><a href="{{ submission.urls.public }}">{{ submission.title }}</a></div>
+                    <div>{{ submission.description }}</div>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/src/pretalx/agenda/templates/agenda/talk.html
+++ b/src/pretalx/agenda/templates/agenda/talk.html
@@ -35,7 +35,7 @@
                 </div>
                 {% for speaker in speakers %}
                     <div class="info">
-                        <div class="speaker">{{ speaker.get_display_name }}</div>
+                        <a href="{% url 'agenda:speaker' event=talk.event.slug slug=speaker.nick %}">{{ speaker.get_display_name }}</a>
                         {% if speaker.talk_profile.biography %}
                             <div>{{ speaker.talk_profile.biography }}</div>
                         {% endif %}

--- a/src/pretalx/agenda/templates/agenda/talk.html
+++ b/src/pretalx/agenda/templates/agenda/talk.html
@@ -25,8 +25,8 @@
             </div>
         </div>
         <div class="col-lg-4 col-md-6 col-xs-12">
-            <div class="speakers">
-                <div class="speaker-header">
+            <div class="bordered-list">
+                <div class="header">
                     {% if speakers.1 %}
                         {% trans "Speakers" %}
                     {% elif speakers.0 %}
@@ -34,7 +34,7 @@
                     {% endif %}
                 </div>
                 {% for speaker in speakers %}
-                    <div class="speaker-info">
+                    <div class="info">
                         <div class="speaker">{{ speaker.get_display_name }}</div>
                         {% if speaker.talk_profile.biography %}
                             <div>{{ speaker.talk_profile.biography }}</div>

--- a/src/pretalx/agenda/urls.py
+++ b/src/pretalx/agenda/urls.py
@@ -11,5 +11,5 @@ agenda_urls = [
 
     url('^(?P<event>\w+)/location/$', location.LocationView.as_view(), name='location'),
     url('^(?P<event>\w+)/talk/(?P<slug>\w+)/$', schedule.TalkView.as_view(), name='talk'),
-    url('^(?P<event>\w+)/speaker/(?P<name>\w+)/$', speaker.SpeakerView.as_view(), name='speaker'),
+    url('^(?P<event>\w+)/speaker/(?P<slug>\w+)/$', speaker.SpeakerView.as_view(), name='speaker'),
 ]

--- a/src/pretalx/agenda/views/speaker.py
+++ b/src/pretalx/agenda/views/speaker.py
@@ -1,5 +1,17 @@
-from django.views.generic import View
+from django.views.generic import DetailView
+
+from pretalx.cfp.views.event import EventPageMixin
+from pretalx.person.models import User
 
 
-class SpeakerView(View):
-    pass
+class SpeakerView(EventPageMixin, DetailView):
+    context_object_name = 'speaker'
+    model = User
+    slug_field = 'nick'
+    template_name = 'agenda/speaker.html'
+
+    def get_context_data(self, *args, **kwargs):
+        ctx = super().get_context_data(*args, **kwargs)
+        ctx['speaker'] = self.object
+        ctx['submissions'] = self.request.event.submissions.filter(speakers__in=[self.object])
+        return ctx

--- a/src/pretalx/static/agenda/scss/_speaker.scss
+++ b/src/pretalx/static/agenda/scss/_speaker.scss
@@ -18,30 +18,31 @@
       border-bottom: 1px solid rgba(0, 0, 0, 0.1);
     }
   }
+}
 
-  .speakers {
-    border: 1px solid #4CAF50;
-    border-top: 4px solid #4CAF50;
-    background-color: rgba(255, 255, 255, 0.76);
-    box-sizing: border-box;
-    color: rgba(0, 0, 0, 0.87);
-    display: block;
-    padding: 5px 10px;
+/* used for speaker list on talk page as well as talk list on speaker page */
+.bordered-list {
+  border: 1px solid #4CAF50;
+  border-top: 4px solid #4CAF50;
+  background-color: rgba(255, 255, 255, 0.76);
+  box-sizing: border-box;
+  color: rgba(0, 0, 0, 0.87);
+  display: block;
+  padding: 5px 10px;
 
-    .speaker-header {
-      font-weight: bold;
-    }
+  .header {
+    font-weight: bold;
+  }
 
-    .speaker-info {
-      margin-top: 8px;
-      padding-top: 8px;
-      margin-bottom: 1rem;
-      border: 0;
-      border-top: 1px solid rgba(0, 0, 0, 0.1);
-    }
+  .info {
+    margin-top: 8px;
+    padding-top: 8px;
+    margin-bottom: 1rem;
+    border: 0;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+  }
 
-    a.speaker {
-      font-weight: bold;
-    }
+  .info a {
+    font-weight: bold;
   }
 }


### PR DESCRIPTION
Add a speaker detail page for the public agenda. The new page displays the speakers nickname, name as well as a list of talks the speaker holds. There is also a link to the speaker page on each of their talks.

I kind of took the idea of having a public speaker page and ran with it. In case you do not like it or you want something changed, just tell me so and I'll adapt this PR.

kind-of-fixes #53?