### PR TITLE
[schedule] make sure the wip_schedule cache is refreshed on freeze()

### DIFF
--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from contextlib import suppress
 
 import pytz
 from django.db import models, transaction
@@ -58,6 +59,10 @@ class Schedule(LogMixin, models.Model):
         TalkSlot.objects.bulk_create(talks)
 
         self.notify_speakers()
+
+        with suppress(AttributeError):
+            del wip_schedule.event.wip_schedule
+
         return self, wip_schedule
 
     def unfreeze(self, user=None):

--- a/src/tests/unit/schedule/test_schedule_model.py
+++ b/src/tests/unit/schedule/test_schedule_model.py
@@ -36,6 +36,13 @@ def test_freeze(talk_slot):
 
 
 @pytest.mark.django_db
+def test_freeze_cache(talk_slot):
+    talk_slot.event.wip_schedule.freeze('Version')
+    # make sure the cache for wip_schedule is invalidated
+    assert talk_slot.event.wip_schedule.version is None
+
+
+@pytest.mark.django_db
 def test_scheduled_talks(talk_slot, room):
     assert talk_slot.schedule.scheduled_talks.count() == 0
     talk_slot.room = room


### PR DESCRIPTION
fixes the following bug:
```python
>>> event.wip_schedule
<Schedule: None>
>>> event.wip_schedule.freeze('Version 2')
>>> event.wip_schedule
<Schedule: Version 2>
(expected: <Schedule: None>)
```

This should, in theory, also happen with `unfreeze()`, but I am not able to replicated it.