### PR TITLE
Fix #72: schedule reset hides talk

### DIFF
--- a/src/tests/unit/schedule/test_schedule_model.py
+++ b/src/tests/unit/schedule/test_schedule_model.py
@@ -43,6 +43,27 @@ def test_freeze_cache(talk_slot):
 
 
 @pytest.mark.django_db
+def test_unfreeze(talk_slot):
+    event = talk_slot.event
+
+    old1, new1 = talk_slot.schedule.freeze('Version 1')
+    talk_slot2 = event.wip_schedule.talks.first()
+    talk_slot2.room = None
+    talk_slot2.save()
+    old2, new2 = event.wip_schedule.freeze('Version 2')
+
+    assert new1 == old2
+
+    schedules = event.schedules.exclude(version=None).order_by('published')
+    assert len(schedules) == 2
+    assert schedules[0].version == 'Version 1'
+    assert schedules[1].version == 'Version 2'
+
+    assert schedules[0].talks.first().room
+    assert not schedules[1].talks.first().room
+
+
+@pytest.mark.django_db
 def test_scheduled_talks(talk_slot, room):
     assert talk_slot.schedule.scheduled_talks.count() == 0
     talk_slot.room = room


### PR DESCRIPTION
This fixes #72. Please refer to the issue for details. It also adds a test or two for `Schedule.unfreeze()`.