### PR TITLE
fix #86 add speaker textbox width

### DIFF
--- a/src/pretalx/orga/templates/orga/settings/team.html
+++ b/src/pretalx/orga/templates/orga/settings/team.html
@@ -22,9 +22,9 @@
                 {% endif %}
             </li>
         {% endfor %}
-        <li><form method="post" action="{{ request.event.orga_urls.invite }}">
+        <li><form method="post" action="{{ request.event.orga_urls.invite }}" class="adder-textbox">
             <input type="text" name="email" />
-            <button type="submit" class="btn btn-sm btn-primary"><span class="fa fa-check"></span></button>
+            <button type="submit" class="btn btn-sm btn-primary"><span class="fa fa-plus"></span></button>
         </form></li>
     </ul>
 

--- a/src/pretalx/orga/templates/orga/submission/speakers.html
+++ b/src/pretalx/orga/templates/orga/submission/speakers.html
@@ -30,9 +30,10 @@
     </table>
 
     <div class="content">
-        <form method="POST" action="{{ submission.orga_urls.new_speaker }}">
-            <input id="input-nick" name="nick" class="form-control typeahead" type="text" placeholder="{% trans "Additional speaker – by nickname if registered, by email to send an invitation" %}">
-            <button type="submit" class="btn btn-secondary"><span class="fa fa-plus"></span></button>
+        {% trans "Additional speaker – by nickname if registered, by email to send an invitation" %}:<br>
+        <form method="POST" action="{{ submission.orga_urls.new_speaker }}" class="adder-textbox">
+            <input id="input-nick" name="nick" class="form-control typeahead" type="text">
+            <button type="submit" class="btn btn-sm btn-primary"><span class="fa fa-plus"></span></button>
         </form>
     </div>
 

--- a/src/pretalx/static/orga/scss/main.scss
+++ b/src/pretalx/static/orga/scss/main.scss
@@ -37,6 +37,25 @@ table .btn-secondary {
   text-decoration: line-through;
 }
 
+.adder-textbox {
+  $height: 2rem;
+
+  display: inline-flex;
+
+  input {
+    height: $height;
+    max-width: 250px;
+  }
+
+  .btn {
+    height: $height;
+    width: $height + 0.1rem;
+    text-align: center;
+    vertical-align: top;
+    margin-left: 5px;
+  }
+}
+
 .flex-container {
   display: flex;
   flex-wrap: no-wrap;


### PR DESCRIPTION
This takes the existing layout and iconography  of the team to style the talk speakers list.
![image](https://user-images.githubusercontent.com/2158203/29754890-f44da8f8-8b8e-11e7-979f-7453f99b1b05.png)

Fixes #86.