### PR TITLE
[orga] pluralize lists on team page

### DIFF
--- a/src/pretalx/orga/templates/orga/settings/team.html
+++ b/src/pretalx/orga/templates/orga/settings/team.html
@@ -10,7 +10,14 @@
             {% endif %}{% endif %}
         {% trans "To invite more members to your team, enter an email address below." %}
     </div>
-    <legend>{{ team|length }} {% trans "Team Members" %}</legend>
+    <legend>
+        {{ team|length }}
+        {% blocktrans trimmed count count=team.count %}
+        Team Member
+        {% plural %}
+        Team Members
+        {% endblocktrans %}
+    </legend>
     <ul>
         {% for member in team %}
             <li>

--- a/src/pretalx/orga/templates/orga/settings/team.html
+++ b/src/pretalx/orga/templates/orga/settings/team.html
@@ -36,7 +36,14 @@
     </ul>
 
     {% if pending %}
-        <legend>{{ pending|length }} {% trans "Pending Invitations" %}</legend>
+        <legend>
+            {{ pending|length }}
+            {% blocktrans trimmed count count=pending.count %}
+            Pending Invitation
+            {% plural %}
+            Pending Invitations
+            {% endblocktrans %}
+        </legend>
         <ul>
             {% for email in pending %}
                 <li>


### PR DESCRIPTION
No more "1 Pending Invitations" or "1 Team Members" on the team page! 🎉 