### PR TITLE
[orga] make the "New Event" button on the orga frontpage more consitent

### DIFF
--- a/src/pretalx/locale/de/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/de/LC_MESSAGES/django.po
@@ -1258,8 +1258,8 @@ msgid "Dates and location"
 msgstr "Datum und Ort"
 
 #: pretalx/orga/templates/orga/dashboard.html:23
-msgid "Uh, a new event? Head over here, please!"
-msgstr "Ui, eine neue Veranstaltung? Hier entlang, bitte!"
+msgid "Uh, a new event?<br>Head over here, please!"
+msgstr "Ui, eine neue Veranstaltung?<br>Hier entlang, bitte!"
 
 #: pretalx/orga/templates/orga/invitation.html:7
 #, python-format

--- a/src/pretalx/orga/templates/orga/dashboard.html
+++ b/src/pretalx/orga/templates/orga/dashboard.html
@@ -20,7 +20,7 @@
         {% endfor %}
         <a href="{% url "orga:event.create" %}"><div class="dashboard-block">
             <h1><span class="fa fa-plus"></span>{% trans "New event" %}</h1>
-            <span class="dashboard-description">{% trans "Uh, a new event? Head over here, please!" %}</span>
+            <span class="dashboard-description">{% trans "Uh, a new event?<br>Head over here, please!" %}</span>
         </div></a>
     </div>
 

--- a/src/pretalx/static/orga/scss/_dashboard.scss
+++ b/src/pretalx/static/orga/scss/_dashboard.scss
@@ -14,7 +14,7 @@
   padding: 15px 5px;
   border: 5px solid white;
   min-height: 160px;
-  min-width: 300px;
+  width: 340px;
   background: #F8F8F8;
 
 

--- a/src/tests/functional/orga/test_auth.py
+++ b/src/tests/functional/orga/test_auth.py
@@ -8,4 +8,4 @@ def test_orga_successful_login(client, user):
     user.save()
     response = client.post(reverse('orga:login'), data={'username': user.nick, 'password': 'testtest'}, follow=True)
     assert response.status_code == 200
-    assert 'Uh, a new event? Head over here, please!' in response.content.decode()
+    assert 'Uh, a new event?' in response.content.decode()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2158203/29777897-e3a4ebc2-8c0d-11e7-9b9c-84cb9eeff7a9.png)

The next inside the "New Event" button is all in one line, which can look a little wonky sometimes. Breaking it into two lines looks nicer, in my opinion:
![image](https://user-images.githubusercontent.com/2158203/29777939-05b1e42c-8c0e-11e7-9f77-13bda4777c4c.png)
