### PR TITLE
Fix frab import

### DIFF
--- a/src/pretalx/orga/management/commands/import_frab.py
+++ b/src/pretalx/orga/management/commands/import_frab.py
@@ -83,5 +83,5 @@ class Command(BaseCommand):
                     )
 
         schedule_version = root.find('version').text
-        event.wip_schedule.freeze(schedule_version)
+        event.wip_schedule.freeze(schedule_version, notify_speakers=False)
         event.schedules.get(version=schedule_version).talks.update(is_visible=True)

--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -33,7 +33,7 @@ class Schedule(LogMixin, models.Model):
         unique_together = (('event', 'version'), )
 
     @transaction.atomic
-    def freeze(self, name, user=None):
+    def freeze(self, name, user=None, notify_speakers=True):
         from pretalx.schedule.models import TalkSlot
         if self.version:
             raise Exception(f'Cannot freeze schedule version: already versioned as "{self.version}".')
@@ -58,7 +58,8 @@ class Schedule(LogMixin, models.Model):
             talks.append(talk.copy_to_schedule(wip_schedule, save=False))
         TalkSlot.objects.bulk_create(talks)
 
-        self.notify_speakers()
+        if notify_speakers:
+            self.notify_speakers()
 
         with suppress(AttributeError):
             del wip_schedule.event.wip_schedule

--- a/src/tests/functional/fixtures/frab_schedule_minimal.xml
+++ b/src/tests/functional/fixtures/frab_schedule_minimal.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='utf-8'?>
+<schedule>
+  <version>1.99b 🍕</version>
+  <conference>
+    <acronym>pw16</acronym>
+    <title>PrivacyWeek 2016</title>
+    <start>2016-10-24</start>
+    <end>2016-10-30</end>
+    <days>7</days>
+    <timeslot_duration>00:30</timeslot_duration>
+  </conference>
+  <day date='2016-10-24' end='2016-10-24T23:00:00+02:00' index='1' start='2016-10-24T09:00:00+02:00'>
+    <room name='Volkskundemuseum'>
+      <event guid='1ed6fafa-20a6-466c-8086-89ae4d3b29e5' id='69'>
+        <date>2016-10-24T09:30:00+02:00</date>
+        <start>09:30</start>
+        <duration>00:30</duration>
+        <room>Volkskundemuseum</room>
+        <slug>pw16-69-eroffnungsrede</slug>
+        <recording>
+          <license />
+          <optout>false</optout>
+        </recording>
+        <title>Eröffnungsrede</title>
+        <subtitle>Privatsphäre im digitalen Zeitalter</subtitle>
+        <track>Privatsphäre im digitalen Zeitalter</track>
+        <type>lecture</type>
+        <language>de</language>
+        <abstract />
+        <description />
+        <logo>/system/events/logos/000/000/069/large/_mini_totoro.png?1477315404</logo>
+        <persons>
+          <person id='76'>Peter Purgathofer</person>
+        </persons>
+        <links />
+        <attachments />
+      </event>
+    </room>
+  </day>
+</schedule>

--- a/src/tests/functional/orga/test_frab_import.py
+++ b/src/tests/functional/orga/test_frab_import.py
@@ -1,0 +1,22 @@
+import pytest
+from django.core.management import call_command
+
+from pretalx.event.models import Event
+from pretalx.person.models import EventPermission, SpeakerProfile, User
+from pretalx.schedule.models import Room, TalkSlot
+from pretalx.submission.models import Submission
+
+
+@pytest.mark.django_db
+def test_frab_import_minimal():
+    call_command('import_frab', 'tests/functional/fixtures/frab_schedule_minimal.xml')
+
+    assert Room.objects.count() == 1
+    assert Room.objects.all()[0].name == 'Volkskundemuseum'
+
+    assert TalkSlot.objects.count() == 2
+    assert TalkSlot.objects.all()[0].schedule.version == '1.99b 🍕'
+    assert TalkSlot.objects.all()[1].schedule.version == None
+
+    assert Event.objects.count() == 1
+    assert Event.objects.all()[0].name == 'PrivacyWeek 2016'


### PR DESCRIPTION
Events created by frab import do not have a mail address. This makes the import crash. The speaker mail addresses are also set the "name@localhost". Sending mails is therefore pretty useless right now anyway. Even if there were proper email addresses, I'm not so sure about generating mails for imported talks.

This just disables sending emails during import. It also adds a very simple frab import test.

```
  File "/home/luto/c3w/pretalx/venv/lib/python3.6/site-packages/django/db/backends/utils.py", line 65, in execute
    return self.cursor.execute(sql, params)
  File "/home/luto/c3w/pretalx/venv/lib/python3.6/site-packages/django/db/backends/sqlite3/base.py", line 328, in execute
    return Database.Cursor.execute(self, query, params)
django.db.utils.IntegrityError: NOT NULL constraint failed: mail_queuedmail.reply_to
```