### PR TITLE
fix event slug url matching

### DIFF
--- a/src/pretalx/agenda/urls.py
+++ b/src/pretalx/agenda/urls.py
@@ -1,18 +1,20 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 
 from .views import feed, location, schedule, speaker
 
 agenda_urls = [
-    url('^(?P<event>\w+)/schedule/$', schedule.ScheduleView.as_view(), name='schedule'),
-    url('^(?P<event>\w+)/schedule/changelog$', schedule.ChangelogView.as_view(), name='schedule.changelog'),
-    url('^(?P<event>\w+)/schedule.xml$', schedule.FrabXmlView.as_view(), name='frab-xml'),
-    url('^(?P<event>\w+)/schedule.xcal$', schedule.FrabXCalView.as_view(), name='frab-xcal'),
-    url('^(?P<event>\w+)/schedule.json$', schedule.FrabJsonView.as_view(), name='frab-json'),
-    url('^(?P<event>\w+)/schedule.ics$', schedule.ICalView.as_view(), name='ical'),
-    url('^(?P<event>\w+)/schedule/feed.xml$', feed.ScheduleFeed(), name='feed'),
+    url('^(?P<event>\w+)/', include([
+        url('^schedule/$', schedule.ScheduleView.as_view(), name='schedule'),
+        url('^schedule/changelog$', schedule.ChangelogView.as_view(), name='schedule.changelog'),
+        url('^schedule.xml$', schedule.FrabXmlView.as_view(), name='frab-xml'),
+        url('^schedule.xcal$', schedule.FrabXCalView.as_view(), name='frab-xcal'),
+        url('^schedule.json$', schedule.FrabJsonView.as_view(), name='frab-json'),
+        url('^schedule.ics$', schedule.ICalView.as_view(), name='ical'),
+        url('^schedule/feed.xml$', feed.ScheduleFeed(), name='feed'),
 
-    url('^(?P<event>\w+)/location/$', location.LocationView.as_view(), name='location'),
-    url('^(?P<event>\w+)/talk/(?P<slug>\w+)/$', schedule.TalkView.as_view(), name='talk'),
-    url('^(?P<event>\w+)/talk/(?P<slug>\w+)/feedback/$', schedule.FeedbackView.as_view(), name='feedback'),
-    url('^(?P<event>\w+)/speaker/(?P<name>\w+)/$', speaker.SpeakerView.as_view(), name='speaker'),
+        url('^location/$', location.LocationView.as_view(), name='location'),
+        url('^talk/(?P<slug>\w+)/$', schedule.TalkView.as_view(), name='talk'),
+        url('^talk/(?P<slug>\w+)/feedback/$', schedule.FeedbackView.as_view(), name='feedback'),
+        url('^speaker/(?P<name>\w+)/$', speaker.SpeakerView.as_view(), name='speaker'),
+    ])),
 ]

--- a/src/pretalx/agenda/urls.py
+++ b/src/pretalx/agenda/urls.py
@@ -1,9 +1,11 @@
 from django.conf.urls import include, url
 
+from pretalx.event.models.event import SLUG_CHARS
+
 from .views import feed, location, schedule, speaker
 
 agenda_urls = [
-    url('^(?P<event>\w+)/', include([
+    url(f'^(?P<event>[{SLUG_CHARS}]+)/', include([
         url('^schedule/$', schedule.ScheduleView.as_view(), name='schedule'),
         url('^schedule/changelog$', schedule.ChangelogView.as_view(), name='schedule.changelog'),
         url('^schedule.xml$', schedule.FrabXmlView.as_view(), name='frab-xml'),

--- a/src/pretalx/cfp/urls.py
+++ b/src/pretalx/cfp/urls.py
@@ -1,9 +1,11 @@
 from django.conf.urls import include, url
 
+from pretalx.event.models.event import SLUG_CHARS
+
 from .views import auth, event, locale, user, wizard
 
 cfp_urls = [
-    url('^(?P<event>\w+)/', include([
+    url(f'^(?P<event>[{SLUG_CHARS}]+)/', include([
         url('^$', event.EventStartpage.as_view(), name='event.start'),
         url('^logout$', auth.LogoutView.as_view(), name='event.logout'),
         url('^reset$', auth.ResetView.as_view(), name='event.reset'),

--- a/src/pretalx/cfp/urls.py
+++ b/src/pretalx/cfp/urls.py
@@ -1,32 +1,31 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 
 from .views import auth, event, locale, user, wizard
 
 cfp_urls = [
-    url('^(?P<event>\w+)/$', event.EventStartpage.as_view(), name='event.start'),
-    url('^(?P<event>\w+)/logout$', auth.LogoutView.as_view(), name='event.logout'),
-    url('^(?P<event>\w+)/reset$', auth.ResetView.as_view(), name='event.reset'),
-    url('^(?P<event>\w+)/reset/(?P<token>\w+)$', auth.RecoverView.as_view(), name='event.recover'),
-    url('^(?P<event>\w+)/login', auth.LoginView.as_view(), name='event.login'),
+    url('^(?P<event>\w+)/', include([
+        url('^$', event.EventStartpage.as_view(), name='event.start'),
+        url('^logout$', auth.LogoutView.as_view(), name='event.logout'),
+        url('^reset$', auth.ResetView.as_view(), name='event.reset'),
+        url('^reset/(?P<token>\w+)$', auth.RecoverView.as_view(), name='event.recover'),
+        url('^login', auth.LoginView.as_view(), name='event.login'),
 
-    url('^(?P<event>\w+)/submit/$',
-        wizard.SubmitStartView.as_view(),
-        name='event.submit'),
-    url('^(?P<event>\w+)/submit/(?P<tmpid>.+)/(?P<step>.+)/$',
-        wizard.SubmitWizard.as_view(url_name='cfp:event.submit', done_step_name='finished'),
-        name='event.submit'),
+        url('^submit/$', wizard.SubmitStartView.as_view(), name='event.submit'),
+        url('^submit/(?P<tmpid>.+)/(?P<step>.+)/$',
+            wizard.SubmitWizard.as_view(url_name='cfp:event.submit', done_step_name='finished'),
+            name='event.submit'),
 
-    url('^(?P<event>\w+)/me$', user.ProfileView.as_view(), name='event.user.view'),
-    url('^(?P<event>\w+)/me/submissions$', user.SubmissionsListView.as_view(), name='event.user.submissions'),
-    url('^(?P<event>\w+)/me/submissions/(?P<code>\w+)/$', user.SubmissionsEditView.as_view(),
-        name='event.user.submission.edit'),
-    url('^(?P<event>\w+)/me/submissions/(?P<code>\w+)/withdraw$', user.SubmissionsWithdrawView.as_view(),
-        name='event.user.submission.withdraw'),
-    url('^(?P<event>\w+)/me/submissions/(?P<code>\w+)/confirm$', user.SubmissionConfirmView.as_view(),
-        name='event.user.submission.confirm'),
+        url('^me$', user.ProfileView.as_view(), name='event.user.view'),
+        url('^me/submissions$', user.SubmissionsListView.as_view(), name='event.user.submissions'),
+        url('^me/submissions/(?P<code>\w+)/$', user.SubmissionsEditView.as_view(),
+            name='event.user.submission.edit'),
+        url('^me/submissions/(?P<code>\w+)/withdraw$', user.SubmissionsWithdrawView.as_view(),
+            name='event.user.submission.withdraw'),
+        url('^me/submissions/(?P<code>\w+)/confirm$', user.SubmissionConfirmView.as_view(),
+            name='event.user.submission.confirm'),
 
-    url('^locale/set', locale.LocaleSet.as_view(),
-        name='locale.set'),
+        url('^locale/set', locale.LocaleSet.as_view(), name='locale.set'),
 
-    url('^$', event.GeneralView.as_view()),
+        url('^$', event.GeneralView.as_view()),
+    ])),
 ]

--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -15,6 +15,8 @@ from urlman import Urls
 from pretalx.common.mixins import LogMixin
 from pretalx.common.models.settings import settings_hierarkey
 
+SLUG_CHARS = 'a-zA-Z0-9.-'
+
 
 @settings_hierarkey.add()
 class Event(LogMixin, models.Model):
@@ -27,7 +29,7 @@ class Event(LogMixin, models.Model):
         help_text=_('Should be short, only contain lowercase letters and numbers, and must be unique.'),
         validators=[
             RegexValidator(
-                regex="^[a-zA-Z0-9.-]+$",
+                regex=f"^[{SLUG_CHARS}]+$",
                 message=_('The slug may only contain letters, numbers, dots and dashes.'),
             ),
         ],

--- a/src/pretalx/orga/urls.py
+++ b/src/pretalx/orga/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 
+from pretalx.event.models.event import SLUG_CHARS
 from pretalx.orga.views import cards
 
 from .views import (
@@ -16,7 +17,7 @@ orga_urls = [
     url('^invitation/(?P<code>\w+)$', settings.InvitationView.as_view(), name='invitation.view'),
     url('^event/new/$', settings.EventDetail.as_view(), name='event.create'),
 
-    url('^event/(?P<event>\w+)/', include([
+    url(f'^event/(?P<event>[{SLUG_CHARS}]+)/', include([
         url('^users$', person.UserList.as_view(), name='event.user_list'),
 
         url('^$', dashboard.EventDashboardView.as_view(), name='event.dashboard'),


### PR DESCRIPTION
See #113 for details :)

Django does not seem to provide an easy way to match slugs within URLs. [The internet](https://stackoverflow.com/questions/31216363/url-pattern-for-alphanumericslug-string-in-django) [recommends](https://stackoverflow.com/questions/23358685/regular-expression-in-url-for-django-slug) to just use an regex for that. So I did. If you know a smarter way, just hit me up and I'll change this around.

The diff is kind of big, because I removed all the duplicate slug-matching from the URLs. This way I only had the replace the regex in three places.