### PR TITLE
CSS validator nitpicking

### DIFF
--- a/src/pretalx/common/css.py
+++ b/src/pretalx/common/css.py
@@ -24,10 +24,6 @@ acceptable_css_properties = set([
     'text-indent', 'unicode-bidi', 'vertical-align', 'voice-family', 'volume',
     'white-space', 'width',
 ])
-acceptable_svg_properties = set([
-    'fill', 'fill-opacity', 'fill-rule', 'stroke', 'stroke-width', 'stroke-linecap',
-    'stroke-linejoin', 'stroke-opacity',
-])
 
 
 def get_key(style, key):
@@ -49,7 +45,7 @@ def validate_key(*, key, style):
         for value in values.split(' '):
             if value not in acceptable_css_keywords and not valid_css_values.match(value):
                 raise ValidationError(_('"{value}" is not allowed as attribute of "{key}"').format(key=key, value=value))
-    elif key not in acceptable_svg_properties:
+    else:
         raise ValidationError(_('You are not allowed to include "{key}" keys in your CSS.').format(key=key))
 
 

--- a/src/pretalx/common/css.py
+++ b/src/pretalx/common/css.py
@@ -45,11 +45,11 @@ def validate_key(*, key, style):
         return
     if not values:
         raise ValidationError(_('"{key}" attribute could not be parsed.').format(key=key))
-    elif key.split('-')[0].lower() in ['background', 'border', 'margin', 'padding']:
+    elif key.split('-')[0] in ['background', 'border', 'margin', 'padding']:
         for value in values.split(' '):
             if value not in acceptable_css_keywords and not valid_css_values.match(value):
                 raise ValidationError(_('"{value}" is not allowed as attribute of "{key}"').format(key=key, value=value))
-    elif key.lower() not in acceptable_svg_properties:
+    elif key not in acceptable_svg_properties:
         raise ValidationError(_('You are not allowed to include "{key}" keys in your CSS.').format(key=key))
 
 

--- a/src/tests/unit/common/test_css.py
+++ b/src/tests/unit/common/test_css.py
@@ -13,7 +13,7 @@ body {
 }
 .some-descriptor {
   border-style: dotted dashed solid double;
-  border-color: red green blue yellow;
+  BORDER-color: red green blue yellow;
 }
 #best-descriptor {
   border: 5px solid red;


### PR DESCRIPTION
1. the CSS parser always returns keys in lower-case. Calling `.lower()` on them doesn't do much. Also add this to the testcase.
2. the CSS parser does not support SVG attributes like `fill`. They never survive `stylesheet.valid`. Checking for them will thus always fail, as they are never present.