### PR TITLE
[tests] schedule.xsd: make sure minutes and seconds are 00-59

### DIFF
--- a/src/tests/functional/fixtures/schedule.xsd
+++ b/src/tests/functional/fixtures/schedule.xsd
@@ -82,7 +82,7 @@
 
   <xs:simpleType name="duration">
     <xs:restriction base="xs:string">
-      <xs:pattern value="([0-9]{1,2}:[0-9]{2})|([0-9]{1,2}:[0-9]{2}:[0-9]{1,2})"/>
+      <xs:pattern value="[0-9]{1,2}:([0-5][0-9]|[0-9])(:([0-5][0-9]|[0-9]))?"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
fixes #94 🎉 